### PR TITLE
Visual Studio 2013 support the function rint()

### DIFF
--- a/metis/GKlib/gk_arch.h
+++ b/metis/GKlib/gk_arch.h
@@ -60,7 +60,7 @@ typedef ptrdiff_t ssize_t;
 
 #ifdef __MSC__
 /* MSC may not have rint() function */
-#if(_MSC_VER < 1900)
+#if(_MSC_VER < 1800)
 #define rint(x) ((int)((x)+0.5))  
 #endif
 


### PR DESCRIPTION
Visual Studio 2013 support the function rint()

[Problem of build on VS 2013 #23](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/23)