### PR TITLE
position independend static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,14 @@ endif()
 ## 		add_library(<myTarget> ...)
 ## 		install_suitesparse_project(<myTarget> "${LIBHDRS}")
 macro(install_suitesparse_project targetName headersList)
+
+	## set position independend code for GCC, Clang, Mingw static libs
+	if(NOT BUILD_SHARED_LIBS)
+		if (NOT MSVC)
+			target_compile_options(${targetName} PRIVATE "-fPIC")
+		endif()
+	endif()
+
 	set_target_properties(${targetName} PROPERTIES PUBLIC_HEADER "${headersList}")
 	install(TARGETS	${targetName}
 			EXPORT 	SuiteSparse

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,9 +107,9 @@ endif()
 ## 		install_suitesparse_project(<myTarget> "${LIBHDRS}")
 macro(install_suitesparse_project targetName headersList)
 
-	## set position independend code for GCC, Clang, Mingw static libs
+	## set position independend code for GCC, Clang static libs
 	if(NOT BUILD_SHARED_LIBS)
-		if (NOT MSVC)
+		if (NOT MINGW AND NOT MSVC)
 			target_compile_options(${targetName} PRIVATE "-fPIC")
 		endif()
 	endif()


### PR DESCRIPTION
- pass compile option -fPIC to create position independent static
libraries that can be used in other dynamic libraries
- for all compilers except MSVC