### PR TITLE
fix: Visual Studio has rint function, at least in versions 2013 and 2015

### DIFF
--- a/metis/CMakeLists.txt
+++ b/metis/CMakeLists.txt
@@ -17,6 +17,12 @@ else()
   set(METIS_LIBRARY_TYPE STATIC)
 endif()
 
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(rint math.h HAVE_RINT)
+if (HAVE_RINT)
+	add_definitions(-DHAVE_RINT)
+endif()
+
 include(${GKLIB_PATH}/GKlibSystem.cmake)
 # Add include directories.
 include_directories(${GKLIB_PATH})

--- a/metis/GKlib/gk_arch.h
+++ b/metis/GKlib/gk_arch.h
@@ -58,9 +58,11 @@ typedef ptrdiff_t ssize_t;
 #define PTRDIFF_MAX  INT64_MAX
 #endif
 
-#ifdef __MSC__
-/* MSC does not have rint() function */
+#ifndef HAVE_RINT
 #define rint(x) ((int)((x)+0.5))  
+#endif
+
+#ifdef __MSC__
 
 /* MSC does not have INFINITY defined */
 #ifndef INFINITY


### PR DESCRIPTION
- this patch checks if rint is available from cmake and the sets a preprocessor variable for compilation
- maybe this patch should be moved to the original metis repo?