### PR TITLE
Fix rint detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,18 @@
 
 PROJECT(SuiteSparseProject)
 
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.1)
+
+# https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
+string(COMPARE EQUAL "${CMAKE_CXX_STANDARD}" "" no_cmake_cxx_standard_set)
+if(no_cmake_cxx_standard_set)
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  message(STATUS "Using default C++ standard ${CMAKE_CXX_STANDARD}")
+else()
+  message(STATUS "Using user specified C++ standard ${CMAKE_CXX_STANDARD}")
+endif()
 
 include(checkGetSuiteSparse.cmake)
 

--- a/metis/CMakeLists.txt
+++ b/metis/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 include(CheckCXXSymbolExists)
-check_cxx_symbol_exists(rint math.h HAVE_RINT)
+check_cxx_symbol_exists(rint cmath HAVE_RINT)
 if (HAVE_RINT)
 	add_definitions(-DHAVE_RINT)
 endif()


### PR DESCRIPTION
Fix https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/71

rint is a C++11 feature, require C++11

also look for `rint` in C++ header `cmath` instead of C header `math.h`