### PR TITLE
Fixed compiling issues related to gk_arch.h in metis/GKlib for VS2017

### DIFF
--- a/metis/GKlib/gk_arch.h
+++ b/metis/GKlib/gk_arch.h
@@ -58,15 +58,17 @@ typedef ptrdiff_t ssize_t;
 #define PTRDIFF_MAX  INT64_MAX
 #endif
 
-#ifndef HAVE_RINT
+#ifdef __MSC__
+/* MSC may not have rint() function */
+#if(_MSC_VER < 1800)
 #define rint(x) ((int)((x)+0.5))  
 #endif
 
-#ifdef __MSC__
-
 /* MSC does not have INFINITY defined */
 #ifndef INFINITY
+#if(_MSC_VER < 1900)
 #define INFINITY FLT_MAX
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
See the other bug report:
https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/47#issuecomment-384564607

This pull request simply reverts the file to (which is better than [the other fix](https://github.com/ComFreek/suitesparse-metis-for-windows/commit/85bc4d06180a7872dbff35753968210877e8472b)):
https://github.com/jlblancoc/suitesparse-metis-for-windows/commit/954dedb70b628749b6df76cad6e5dec7e1e37b97#diff-845d4516c2d0a6c30600d23c4464d3ed

Passed compilation using VS2017 x64.