### PR TITLE
ci: add Continuous Integration for gcc, clang, MSVC and mingw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,77 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+# define the build matrix
+env:
+  global:
+    - RUN_TESTS: false
+    - BUILD_METIS: ON
+
+matrix:
+  include:
+    # Linux {
+
+    #   Ubuntu 18.04
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx11
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx17
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=clang-cxx17
+        BUILD_PACKAGES="clang"
+    # } // end Linux
+
+    # Windows build with mingw-w64 on Ubuntu 18.04
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=linux-mingw-w64-cxx11
+        BUILD_PACKAGES="cmake mingw-w64 wine-stable"
+        BUILD_METIS=OFF
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=linux-mingw-w64-cxx17
+        BUILD_PACKAGES="cmake mingw-w64 wine-stable"
+        BUILD_METIS=OFF
+
+before_install:
+  # use the Dockerfile.<distro>.template file for building the image with sed magic
+  - |
+    sed \
+    -e "s/@BUILD_FLAVOR@/${BUILD_FLAVOR}/g" \
+    -e "s/@BUILD_RELEASE@/${BUILD_RELEASE}/g" \
+    -e "s/@BUILD_ARCH@/${BUILD_ARCH}/g" \
+    -e "s/@BUILD_PACKAGES@/${BUILD_PACKAGES}/g" \
+    ci/Dockerfile.$BUILD_FLAVOR.template | tee ci/Dockerfile.$BUILD_FLAVOR.$BUILD_RELEASE.$BUILD_ARCH
+  - docker build -f ci/Dockerfile.$BUILD_FLAVOR.$BUILD_RELEASE.$BUILD_ARCH -t suitesparse-devel .
+
+script: |
+  # run the respective .travis.<distro>.sh script
+  docker run \
+  -e BUILD_FLAVOR="$BUILD_FLAVOR" \
+  -e BUILD_RELEASE="$BUILD_RELEASE" \
+  -e BUILD_ARCH="$BUILD_ARCH" \
+  -e TOOLCHAIN="$TOOLCHAIN" \
+  -e BUILD_METIS="$BUILD_METIS" \
+  -e RUN_TESTS="$RUN_TESTS" \
+  -it suitesparse-devel ci/travis.$BUILD_FLAVOR.sh
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,53 @@
+# global environment variables
+environment:
+  global:
+    # path to source directory of project to be built
+    PROJECT_DIR: .
+    # output test results for failing tests
+    CTEST_OUTPUT_ON_FAILURE: 1
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    BUILD_METIS: ON
+
+  # test matrix
+  matrix:
+
+    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+      GENERATOR: "Visual Studio 14 2015 Win64"
+
+    - TOOLCHAIN: "vs-14-2015-win64"
+      GENERATOR: "Visual Studio 14 2015 Win64"
+
+    - TOOLCHAIN: "vs-15-2017-win64"
+      GENERATOR: "Visual Studio 15 2017 Win64"
+
+    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+      GENERATOR: "Visual Studio 15 2017 Win64"
+
+    - TOOLCHAIN: "mingw-cxx11"
+      GENERATOR: "MinGW Makefiles"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin"
+      BUILD_METIS: OFF
+
+    - TOOLCHAIN: "mingw-cxx17"
+      GENERATOR: "MinGW Makefiles"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin"
+      BUILD_METIS: OFF
+
+install:
+  # Remove entry with sh.exe from PATH to fix error with MinGW toolchain
+  # (For MinGW make to work correctly sh.exe must NOT be in your path)
+  # * http://stackoverflow.com/a/3870338/2288008
+  - cmd: set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+
+  # set MINGW path
+  - cmd: IF DEFINED MINGW_PATH set PATH=%MINGW_PATH%;%PATH%
+
+  # Visual Studio 15 2017: Mimic behavior of older versions
+  - cmd: set VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools
+
+build_script:
+  - cmd: cmake -H. -B_build_%TOOLCHAIN%_Debug -G "%GENERATOR%" -DCMAKE_INSTALL_PREFIX=%cd%\_install_%TOOLCHAIN%_DEBUG -DCMAKE_TOOLCHAIN_FILE="%cd%\ci\toolchains\%TOOLCHAIN%.cmake" -DBUILD_METIS=%BUILD_METIS%
+  - cmd: cmake --build _build_%TOOLCHAIN%_Debug --config Debug --target install
+  #- cmd: cmake -H. -B_build_%TOOLCHAIN%_Release -G "%GENERATOR%" -DCMAKE_INSTALL_PREFIX=%cd%\_install_%TOOLCHAIN%_Release -DCMAKE_TOOLCHAIN_FILE="%cd%\toolchains\%TOOLCHAIN%.cmake" -DBUILD_METIS=%BUILD_METIS%
+  #- cmd: cmake --build _build_%TOOLCHAIN%_Release --config Release --target install
+

--- a/ci/Dockerfile.ubuntu.template
+++ b/ci/Dockerfile.ubuntu.template
@@ -1,0 +1,16 @@
+# Build Ubuntu image
+FROM @BUILD_ARCH@/@BUILD_FLAVOR@:@BUILD_RELEASE@
+
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  @BUILD_PACKAGES@ \
+  build-essential \
+  g++ \
+  cmake \
+  liblapack-dev libblas-dev
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app

--- a/ci/toolchains/.gitignore
+++ b/ci/toolchains/.gitignore
@@ -1,0 +1,2 @@
+# allow toolchain files to be tracked by git
+!*.cmake

--- a/ci/toolchains/clang-cxx17.cmake
+++ b/ci/toolchains/clang-cxx17.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-cxx11.cmake
+++ b/ci/toolchains/gcc-cxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-cxx17.cmake
+++ b/ci/toolchains/gcc-cxx17.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/linux-mingw-w64-cxx11.cmake
+++ b/ci/toolchains/linux-mingw-w64-cxx11.cmake
@@ -1,0 +1,33 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64`
+#    *) cmake -H. -B_build_mingw -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/linux-mingw-w64.cmake"
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# set compiler
+set(CMAKE_C_COMPILER   ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER  ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# use emulator for `try_run` calls
+set(CMAKE_CROSSCOMPILING_EMULATOR wine64)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/linux-mingw-w64-cxx17.cmake
+++ b/ci/toolchains/linux-mingw-w64-cxx17.cmake
@@ -1,0 +1,33 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64`
+#    *) cmake -H. -B_build_mingw -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/linux-mingw-w64.cmake"
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# set compiler
+set(CMAKE_C_COMPILER   ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER  ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# use emulator for `try_run` calls
+set(CMAKE_CROSSCOMPILING_EMULATOR wine64)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/mingw-cxx11.cmake
+++ b/ci/toolchains/mingw-cxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="%cd%\toolchains\mingw.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/mingw-cxx17.cmake
+++ b/ci/toolchains/mingw-cxx17.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="%cd%\toolchains\mingw.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/vs-14-2015-sdk-8-1.cmake
+++ b/ci/toolchains/vs-14-2015-sdk-8-1.cmake
@@ -1,0 +1,2 @@
+# set c++ standard
+set(CMAKE_SYSTEM_VERSION 8.1)

--- a/ci/toolchains/vs-14-2015-win64.cmake
+++ b/ci/toolchains/vs-14-2015-win64.cmake
@@ -1,0 +1,1 @@
+# dummy, nothing extra to set

--- a/ci/toolchains/vs-15-2017-win64-cxx17.cmake
+++ b/ci/toolchains/vs-15-2017-win64-cxx17.cmake
@@ -1,0 +1,2 @@
+# set c++ standard
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} /std:c++17")

--- a/ci/toolchains/vs-15-2017-win64.cmake
+++ b/ci/toolchains/vs-15-2017-win64.cmake
@@ -1,0 +1,1 @@
+# dummy, nothing extra to set

--- a/ci/travis.ubuntu.sh
+++ b/ci/travis.ubuntu.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+set -x
+
+uname -a
+
+cmake -H. -B_build_${TOOLCHAIN} -DCMAKE_INSTALL_PREFIX=${PWD}/_install_${TOOLCHAIN} -DCMAKE_TOOLCHAIN_FILE="${PWD}/ci/toolchains/${TOOLCHAIN}.cmake" -DBUILD_METIS=${BUILD_METIS}
+cmake --build _build_${TOOLCHAIN} --target install -- -j4
+
+if [ "$RUN_TESTS" = true ]; then
+	case "$TOOLCHAIN" in linux-mingw*)
+		echo "copy runtime libraries needed for tests into build directory"
+		cp /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll /usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/{libstdc++-6.dll,libgcc_s_seh-1.dll} _build_${TOOLCHAIN}
+	esac
+	CTEST_OUTPUT_ON_FAILURE=1 cmake --build _build_${TOOLCHAIN} --target test
+fi
+
+


### PR DESCRIPTION
notes:
- linux builds using Ubuntu 18.04 (bionic)
- don't build metis on mingw-w64 (build fails to fing GKlib)

build configurations:
- linux:
  - clang-cxx17
  - gcc-cxx11
  - gcc-cxx17
  - linux-mingw-w64-cxx11 (cross compilation)
  - linux-mingw-w64-cxx17 (cross compilation)
- windows:
  - mingw-cxx11
  - mingw-cxx17
  - vs-14-2015-sdk-8-1
  - vs-14-2015-win64
  - vs-15-2017-win64-cxx17
  - vs-15-2017-win64

builds:
- travis: https://travis-ci.org/NeroBurner/suitesparse-metis-for-windows/builds/467474832
- appveyor: https://ci.appveyor.com/project/NeroBurner/suitesparse-metis-for-windows/builds/20983090

before merging you'd have to enable this repo on travis-ci and appveyor by linking your gihub account to these services and enabling CI on both services