### PR TITLE
Hunter: update Gate to v0.9.2 to fix Hunter build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- update copy of HunterGate to v0.9.2 to fix Hunter build
+
 # Release 1.6.0: December 3rd, 2022
 - Add option WITH_OPENBLAS to replace generic BLAS and LAPACK (See README for details)
 - Hunter: update to v0.24.9 for OpenBLAS v0.3.21


### PR DESCRIPTION
I updated Hunter without checking if embedded the HunterGate needs an update as well. Well, it does, so update it to the latest available HunterGate release.

With this Hunter is able to build SuiteSparse again.

@jlblancoc can I merge this and create a v1.6.1 bugfix release of SuiteSparse-metis-for-windows?