### PR TITLE
Fix METIS_DIR not used for add_subdirectory() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - If `BUILD_METIS=ON` extract and provide `SuiteSparse_METIS_VERSION` in generated config [#109](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/109)
+- Fix `METIS_DIR` not used for `add_subdirectory()` call [#110](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/110)
 
 # Release 1.6.1: December 5th, 2022
 - update copy of HunterGate to v0.9.2 to fix Hunter build [#108](https://github.com/jlblancoc/suitesparse-metis-for-windows/pull/108)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(BUILD_METIS)
 			)
 		endif()
 	endif()
-    add_subdirectory(SuiteSparse/metis-5.1.0) ## important part for building metis from its src files
+  add_subdirectory("${METIS_DIR}" "metis") ## important part for building metis from its src files
 
   # extract METIS version string from metis.h header
   set(_METIS_VERSION_HEADER ${METIS_DIR}/include/metis.h)


### PR DESCRIPTION
Actually use the `METIS_DIR` CMake cache variable for the `add_subdirectory()` call (instead of the hard-coded `SuiteSparse/metis-5.1.0` path).

Fixes: https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/110