### PR TITLE
Fixes CMake config file when OpenBLAS was not used

### DIFF
--- a/cmake/SuiteSparse-config-install.cmake.in
+++ b/cmake/SuiteSparse-config-install.cmake.in
@@ -5,7 +5,7 @@ get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_PREFIX}" PATH)
 get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_PREFIX}" PATH)
 
 include(CMakeFindDependencyMacro)
-set(_SuiteSparse_WITH_OPENBLAS @WITH_OPENBLAS)
+set(_SuiteSparse_WITH_OPENBLAS @WITH_OPENBLAS@)
 if (_SuiteSparse_WITH_OPENBLAS)
   # SuiteSparse was built with OpenBLAS::OpenBLAS cmake target
   # client projects should use OpenBLAS as well to not mix BLAS/LAPACK


### PR DESCRIPTION
A missing `@` would prevent the correct substitution of the `WITH_OPENBLAS` value at configuration time. Therefore, the `if` condition would always be met by an external project (since the variable `_SuiteSparse_WITH_OPENBLAS` would have value `@WITH_OPENBLAS`).