### PR TITLE
Increase minimum CMake version to v3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Increase minimum required CMake version to v3.5 to prevent deprecation warnings [#117](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/117).
 
 # Release 1.7.0: December 21st, 2022
 - If `BUILD_METIS=ON` extract and provide `SuiteSparse_METIS_VERSION` in generated config [#109](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/109)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,9 @@ HunterGate(
   URL "https://github.com/cpp-pm/hunter/archive/v0.24.9.tar.gz"
   SHA1 "09b7e533d3da57eec51765aa73041ecd5ec94e60"
 )
-project(SuiteSparseProject)
+cmake_minimum_required(VERSION 3.5)
 
-cmake_minimum_required(VERSION 3.1)
+project(SuiteSparseProject)
 
 # https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
 string(COMPARE EQUAL "${CMAKE_CXX_STANDARD}" "" no_cmake_cxx_standard_set)

--- a/SuiteSparse/metis-5.1.0/CMakeLists.txt
+++ b/SuiteSparse/metis-5.1.0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(METIS)
 
 set(GKLIB_PATH "GKlib" CACHE PATH "path to GKlib")


### PR DESCRIPTION
CMake 3.27 starts to issue deprecation warnings when projects with a CMake policy below v3.5 are detected.

To get rid of these warnings increase the minimum required CMake version to v3.5.

Fixes: https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/117