### PR TITLE
Add option `METIS_IDXTYPEWIDTH` with default 64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Increase minimum required CMake version to v3.5 to prevent deprecation warnings [#117](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/117).
+- Add option `METIS_IDXTYPEWIDTH` with default `64` to override the index type used for `metis.h` [#116](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/116).
 
 # Release 1.7.0: December 21st, 2022
 - If `BUILD_METIS=ON` extract and provide `SuiteSparse_METIS_VERSION` in generated config [#109](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/109)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if(BUILD_METIS)
 		if(NOT alreadyModified)
 			file(APPEND "${METIS_DIR}/libmetis/CMakeLists.txt"
 			"
-				set_target_properties(metis PROPERTIES PUBLIC_HEADER \"../include/metis.h\")
+				set_target_properties(metis PROPERTIES PUBLIC_HEADER \"\${CMAKE_CURRENT_BINARY_DIR}/../include/metis.h\")
 				install(TARGETS metis ## this line is also the string pattern to check if the modification had already done
 						EXPORT 	SuiteSparseTargets
 						RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/SuiteSparse/metis-5.1.0/CMakeLists.txt
+++ b/SuiteSparse/metis-5.1.0/CMakeLists.txt
@@ -20,7 +20,7 @@ endif(SHARED)
 include(${GKLIB_PATH}/GKlibSystem.cmake)
 # Add include directories.
 include_directories(${GKLIB_PATH})
-include_directories(include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 # Recursively look for CMakeLists.txt in subdirs.
 add_subdirectory("include")
 add_subdirectory("libmetis")

--- a/SuiteSparse/metis-5.1.0/include/CMakeLists.txt
+++ b/SuiteSparse/metis-5.1.0/include/CMakeLists.txt
@@ -1,3 +1,9 @@
+# make IDXTYPEWIDTH configurable
+file(READ metis.h metis_header)
+set(METIS_IDXTYPEWIDTH 64 CACHE STRING "Specifies the width of the elementary data type that will hold information about vertices and their adjacency lists.")
+string(REPLACE "#define IDXTYPEWIDTH 64" "#define IDXTYPEWIDTH ${METIS_IDXTYPEWIDTH}" metis_header "${metis_header}")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/metis.h" "${metis_header}")
+
 if(METIS_INSTALL)
-  install(FILES metis.h DESTINATION include)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/metis.h DESTINATION include)
 endif()

--- a/SuiteSparse/metis-5.1.0/libmetis/CMakeLists.txt
+++ b/SuiteSparse/metis-5.1.0/libmetis/CMakeLists.txt
@@ -15,7 +15,7 @@ if(METIS_INSTALL)
     ARCHIVE DESTINATION lib)
 endif()
 
-				set_target_properties(metis PROPERTIES PUBLIC_HEADER "../include/metis.h")
+				set_target_properties(metis PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_BINARY_DIR}/../include/metis.h")
 				install(TARGETS metis ## this line is also the string pattern to check if the modification had already done
 						EXPORT 	SuiteSparseTargets
 						RUNTIME DESTINATION bin


### PR DESCRIPTION
When building ceres-solver 2.2.0 with SuiteSparse+Metis and EigenSparse support the build errors because the definition of `#define IDXTYPEWIDTH 64` in `metis.h` and the hard coded index type of `ceres-solver` of `int`.

Add a CMake configuration option `METIS_IDXTYPEWIDTH` to override the `IDXTYPEWIDTH` with 32 again to be compatible with ceres-solver 2.2.0. The default value is kept to be `64` to not change the default behavior, but add the possibility to override the change back to `32`.

Fixes: https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/116