### PR TITLE
Release 7.5.1-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# Release 7.5.1-1: 2024-01-23
 - Update SuiteSparse to 7.5.1 with embedded Metis [#125](https://github.com/jlblancoc/suitesparse-metis-for-windows/pull/125)
   - fixes Metis based segmentation fault [#123](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/123)
   - remove `SuiteSparse::metis` target as Metis is now a private dependency of `CHOLMOD` module
@@ -9,19 +9,19 @@
 - More generic `OpenBLAS` linkage [#122](https://github.com/jlblancoc/suitesparse-metis-for-windows/pull/122)
 - Update Hunter to `v0.25.3` to fix CMake 3.25 deprecation warnings [#126](https://github.com/jlblancoc/suitesparse-metis-for-windows/pull/126)
 
-# Release 1.8.0: October 25th, 2023
+# Release 1.8.0: 2023-10-25
 - Increase minimum required CMake version to v3.5 to prevent deprecation warnings [#117](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/117).
 - Add option `METIS_IDXTYPEWIDTH` with default `64` to override the index type used for `metis.h` [#116](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/116).
 
-# Release 1.7.0: December 21st, 2022
+# Release 1.7.0: 2023-12-21
 - If `BUILD_METIS=ON` extract and provide `SuiteSparse_METIS_VERSION` in generated config [#109](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/109)
 - Fix `METIS_DIR` not used for `add_subdirectory()` call [#110](https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/110)
 - Fix `@WITH_OPENBLAS` substitution in generated cmake-config file [#113](https://github.com/jlblancoc/suitesparse-metis-for-windows/pull/113)
 
-# Release 1.6.1: December 5th, 2022
+# Release 1.6.1: 2022-12-05
 - update copy of HunterGate to v0.9.2 to fix Hunter build [#108](https://github.com/jlblancoc/suitesparse-metis-for-windows/pull/108)
 
-# Release 1.6.0: December 3rd, 2022
+# Release 1.6.0: 2022-12-03
 - Add option WITH_OPENBLAS to replace generic BLAS and LAPACK (See README for details)
 - Hunter: update to v0.24.9 for OpenBLAS v0.3.21
 - Options to use TBB and to build shared libraries


### PR DESCRIPTION
From now on use the upstream version and append an increasing number for our releases. When the next upstream version change is done reset the counter to `1`.

Changed the log timestamp to the less localized `YYYY-MM-DD` ISO format.

After the merge I'll tag this commit with `v7.5.1-1` and try to push it